### PR TITLE
fix: access token expiry

### DIFF
--- a/src/siwt.test.ts
+++ b/src/siwt.test.ts
@@ -1,3 +1,4 @@
+import { ACCESS_TOKEN_EXPIRATION } from './constants'
 import { validPkh } from './fixtures'
 import * as SUT from './siwt'
 import { Comparator, Network } from './types'
@@ -94,12 +95,10 @@ describe('./siwt', () => {
       const expectedSignPayload = {
         sub: 'PKH',
         iss: 'ISSUER',
-        iat: expect.any(Number),
-        exp: expect.any(Number),
       }
 
       expect(result).toEqual('JWT')
-      expect(signStub).toHaveBeenCalledWith(expectedSignPayload, 'ACCESS TOKEN SECRET')
+      expect(signStub).toHaveBeenCalledWith(expectedSignPayload, 'ACCESS TOKEN SECRET', { expiresIn: ACCESS_TOKEN_EXPIRATION })
     })
   })
 

--- a/src/siwt.ts
+++ b/src/siwt.ts
@@ -66,10 +66,9 @@ export const _generateAccessToken =
       {
         ...claims,
         sub: pkh,
-        iat: Date.now(),
-        exp: add(Date.now(), ACCESS_TOKEN_EXPIRATION),
       },
       process.env.ACCESS_TOKEN_SECRET as string,
+      { expiresIn: ACCESS_TOKEN_EXPIRATION }
     )
 export const generateAccessToken = _generateAccessToken(jwt?.sign)
 

--- a/src/utils/siwt.utils.ts
+++ b/src/utils/siwt.utils.ts
@@ -11,7 +11,6 @@ import {
   pathEq,
   pathOr,
   pipe,
-  pluck,
   prop,
   propEq,
   propOr,


### PR DESCRIPTION
# Scope

Fix access token expiration

# Work done

Update the generateAccessToken function to correctly handle expiration in line with the other generateToken functions